### PR TITLE
Add Labels for the resource pack and mods tabs

### DIFF
--- a/src/main/java/io/github/koxx12dev/universal/guis/Installer.form
+++ b/src/main/java/io/github/koxx12dev/universal/guis/Installer.form
@@ -2,14 +2,14 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.github.koxx12dev.universal.guis.Installer">
   <grid id="27dc6" binding="pane" layout-manager="GridBagLayout">
     <constraints>
-      <xy x="139" y="20" width="583" height="458"/>
+      <xy x="154" y="116" width="583" height="518"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="2bcbf" class="javax.swing.JButton" binding="InstallButton">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -21,7 +21,7 @@
       </component>
       <tabbedpane id="a7990" binding="ModTabPane">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="200" height="200"/>
           </grid>
           <gridbag weightx="0.0" weighty="0.0"/>
@@ -55,7 +55,7 @@
       </tabbedpane>
       <tabbedpane id="e278b" binding="PackTabPane">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="200" height="200"/>
           </grid>
           <gridbag weightx="0.0" weighty="0.0"/>
@@ -87,6 +87,24 @@
           </scrollpane>
         </children>
       </tabbedpane>
+      <component id="2af79" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Resource Packs"/>
+        </properties>
+      </component>
+      <component id="899cb" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Mods"/>
+        </properties>
+      </component>
     </children>
   </grid>
   <inspectionSuppressions>

--- a/src/main/java/io/github/koxx12dev/universal/guis/Installer.form
+++ b/src/main/java/io/github/koxx12dev/universal/guis/Installer.form
@@ -2,7 +2,7 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.github.koxx12dev.universal.guis.Installer">
   <grid id="27dc6" binding="pane" layout-manager="GridBagLayout">
     <constraints>
-      <xy x="154" y="116" width="583" height="518"/>
+      <xy x="154" y="116" width="583" height="547"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -90,7 +90,7 @@
       <component id="2af79" class="javax.swing.JLabel">
         <constraints>
           <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-          <gridbag weightx="0.0" weighty="0.0"/>
+          <gridbag weightx="0.0" weighty="0.0" ipady="10"/>
         </constraints>
         <properties>
           <text value="Resource Packs"/>
@@ -99,7 +99,7 @@
       <component id="899cb" class="javax.swing.JLabel">
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-          <gridbag weightx="0.0" weighty="0.0"/>
+          <gridbag weightx="0.0" weighty="0.0" ipady="10"/>
         </constraints>
         <properties>
           <text value="Mods"/>

--- a/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
+++ b/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
@@ -675,7 +675,7 @@ public class Installer {
         GridBagConstraints gbc;
         gbc = new GridBagConstraints();
         gbc.gridx = 0;
-        gbc.gridy = 1;
+        gbc.gridy = 2;
         gbc.gridwidth = 3;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         pane.add(InstallButton, gbc);
@@ -684,7 +684,7 @@ public class Installer {
         ModTabPane.setPreferredSize(new Dimension(270, 460));
         gbc = new GridBagConstraints();
         gbc.gridx = 0;
-        gbc.gridy = 0;
+        gbc.gridy = 1;
         gbc.fill = GridBagConstraints.BOTH;
         pane.add(ModTabPane, gbc);
         ModScrollPane = new JScrollPane();
@@ -700,7 +700,7 @@ public class Installer {
         PackTabPane.setPreferredSize(new Dimension(270, 460));
         gbc = new GridBagConstraints();
         gbc.gridx = 2;
-        gbc.gridy = 0;
+        gbc.gridy = 1;
         gbc.fill = GridBagConstraints.BOTH;
         pane.add(PackTabPane, gbc);
         PackScrollPane = new JScrollPane();
@@ -711,6 +711,18 @@ public class Installer {
         PackPane = new JPanel();
         PackPane.setLayout(new GridBagLayout());
         PackScrollPane.setViewportView(PackPane);
+        final JLabel label1 = new JLabel();
+        label1.setText("Resource Packs");
+        gbc = new GridBagConstraints();
+        gbc.gridx = 2;
+        gbc.gridy = 0;
+        pane.add(label1, gbc);
+        final JLabel label2 = new JLabel();
+        label2.setText("Mods");
+        gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        pane.add(label2, gbc);
     }
 
     /**

--- a/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
+++ b/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
@@ -716,12 +716,14 @@ public class Installer {
         gbc = new GridBagConstraints();
         gbc.gridx = 2;
         gbc.gridy = 0;
+        gbc.ipady = 10;
         pane.add(label1, gbc);
         final JLabel label2 = new JLabel();
         label2.setText("Mods");
         gbc = new GridBagConstraints();
         gbc.gridx = 0;
         gbc.gridy = 0;
+        gbc.ipady = 10;
         pane.add(label2, gbc);
     }
 


### PR DESCRIPTION
When I started up the client it was a bit hard for me to figure out what was going on and that one side was mods and the other side was resource packs. I think adding these labels will make it much more clear for people. 

Below is an image for how it looks like:

![afbeelding](https://github.com/SkyblockClient/SkyClient-Installer-Java/assets/24190849/11dd13e0-4108-4822-8f7f-77342b15d6bb)

