### PR TITLE
Added a file chooser if the .minecraft directory can't be found 

### DIFF
--- a/src/main/java/io/github/koxx12dev/universal/SkyclientUniversal.java
+++ b/src/main/java/io/github/koxx12dev/universal/SkyclientUniversal.java
@@ -72,11 +72,19 @@ public class SkyclientUniversal {
             minecraft = new File(System.getProperty("user.home")+"/Library/Application Support/minecraft");
         } else if(System.getProperty("os.name").toLowerCase().contains("linux")){
             minecraft = new File(System.getProperty("user.home")+"/.minecraft");
-        } else if(System.getProperty("os.name").toLowerCase().contains("windows")){
+        }
+        else if(System.getProperty("os.name").toLowerCase().contains("windows")){
             minecraft = new File(System.getProperty("user.home")+"/AppData/Roaming/.minecraft");
-        } else {
-            JOptionPane.showMessageDialog(null, "Unsupported OS!\nPlease use a supported OS to run this program!\n\nSupported OS: Windows, MacOS, Linux", "Unsupported OS", JOptionPane.ERROR_MESSAGE);
-            System.exit(0);
+        }
+        else {
+            JOptionPane.showMessageDialog(null, "Could not automatically determine the location of your .minecraft directory.\nClick ok to select it yourself.", "Could not find .minecraft directory", JOptionPane.WARNING_MESSAGE);
+            minecraft = Installer.selectMinecraftDirectory();
+        }
+
+        // Keep trying until we have a valid file path
+        while (!minecraft.exists() || !(new File(minecraft, "launcher_profiles.json").exists())) {
+            JOptionPane.showMessageDialog(null, "The .minecraft directory does not exist or does not have a launcher_profiles.json inside of it.\nClick ok to select a .minecraft yourself.", "Invalid .minecraft directory", JOptionPane.WARNING_MESSAGE);
+           minecraft = Installer.selectMinecraftDirectory();
         }
 
         skyclient = new File(minecraft, "skyclient");

--- a/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
+++ b/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
@@ -245,6 +245,17 @@ public class Installer {
         });
     }
 
+    public static File selectMinecraftDirectory() {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setDialogTitle("Select .minecraft directory");
+        chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY | JFileChooser.OPEN_DIALOG);
+        chooser.setAcceptAllFileFilterUsed(false); // Disable All files option
+        chooser.setFileHidingEnabled(false);
+        chooser.setVisible(true);
+        chooser.showOpenDialog(null);
+        return chooser.getSelectedFile();
+    }
+
     //https://stackoverflow.com/questions/14548808/scale-the-imageicon-automatically-to-label-size
     public static BufferedImage resize(BufferedImage image, int width, int height, boolean pixelated) {
         BufferedImage resizedImg = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);


### PR DESCRIPTION
I don't have my .minecraft directory in the standard location. So I added that it will ask the user where their .minecraft directory is if it can't be found automatically or if there is no launch_profiles.json in the directory.