### PR TITLE
Add a tooltip to each label and image with the description of the pack or mod.

### DIFF
--- a/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
+++ b/src/main/java/io/github/koxx12dev/universal/guis/Installer.java
@@ -284,6 +284,7 @@ public class Installer {
             Name.setPreferredSize(new Dimension(150, 67));
             Name.setMinimumSize(new Dimension(150, 67));
             Name.setText(mod.getDisplay());
+            Name.setToolTipText(mod.getDescription());
             gbc = new GridBagConstraints();
             gbc.gridx = 1;
             gbc.gridy = 0;
@@ -292,6 +293,7 @@ public class Installer {
             JLabel Image = new JLabel();
             Image.setHorizontalAlignment(SwingConstants.LEFT);
             Image.setHorizontalTextPosition(SwingConstants.TRAILING);
+            Image.setToolTipText(mod.getDescription());
             BufferedImage icon;
             if (mod.icon != null) {
                 if (new File(SkyclientUniversal.cache, mod.getIcon()).exists()) {
@@ -450,6 +452,7 @@ public class Installer {
             Name.setPreferredSize(new Dimension(150, 67));
             Name.setMinimumSize(new Dimension(150, 67));
             Name.setText(pack.getDisplay());
+            Name.setToolTipText(pack.getDescription());
             gbc = new GridBagConstraints();
             gbc.gridx = 1;
             gbc.gridy = 0;
@@ -458,6 +461,7 @@ public class Installer {
             JLabel Image = new JLabel();
             Image.setHorizontalAlignment(SwingConstants.LEFT);
             Image.setHorizontalTextPosition(SwingConstants.TRAILING);
+            Image.setToolTipText(pack.getDescription());
             BufferedImage icon;
             if (new File(SkyclientUniversal.cache, pack.getIcon()).exists()) {
                 icon = resize(ImageIO.read(new File(SkyclientUniversal.cache, pack.getIcon())), 50, 50, Objects.equals(pack.icon_scaling, "pixel"));


### PR DESCRIPTION
This should close #36. For some reason the tooltips only show up if you are not on the first tab of the JTabbedPane. I hope someone knows why that happens so that can be resolved. But if we don't know then this at least ads the descriptions to the other tabs so I think it is still valuable to merge.

![Tooltip example](https://github.com/SkyblockClient/SkyClient-Installer-Java/assets/24190849/c3057101-cf9f-42d9-ac52-3c03a51bdcba)

I also tried for a bit to add the descriptions in each DataPanel but there was not really enough space for that. It would require the gui to be much bigger.

 Another option I thought about is to have a big label or text area above the install button and just put the description of the hovered name or image in that box. But this solution is much simpler. 